### PR TITLE
Properties, lazy computation and system version

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -15,7 +15,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         
         /*** Display the device version ***/
-        switch Device.version() {
+        switch Device.version {
             /*** iPhone ***/
             case .iPhone4:       print("It's an iPhone 4")
             case .iPhone4S:      print("It's an iPhone 4S")
@@ -56,7 +56,7 @@ class ViewController: UIViewController {
         }
         
         /*** Display the device screen size ***/
-        switch Device.size() {
+        switch Device.size {
             case .Screen3_5Inch: print("It's a 3.5 inch screen")
             case .Screen4Inch:   print("It's a 4 inch screen")
             case .Screen4_7Inch: print("It's a 4.7 inch screen")
@@ -64,7 +64,7 @@ class ViewController: UIViewController {
             default:             print("Unknown size")
         }
         
-        switch Device.type() {
+        switch Device.type {
             case .iPod:         print("It's an iPod")
             case .iPhone:       print("It's an iPhone")
             case .iPad:         print("It's an iPad")
@@ -73,15 +73,15 @@ class ViewController: UIViewController {
         }
         
         /*** Helpers ***/
-        if Device.isEqualToScreenSize(Size.Screen4Inch) {
+        if Device.size == .Screen4Inch {
             print("It's a 4 inch screen")
         }
         
-        if Device.isLargerThanScreenSize(Size.Screen4_7Inch) {
+        if Device.size > .Screen4_7Inch {
             print("Your device screen is larger than 4.7 inch")
         }
         
-        if Device.isSmallerThanScreenSize(Size.Screen4_7Inch) {
+        if Device.size < .Screen4_7Inch {
             print("Your device screen is smaller than 4.7 inch")
         }
     }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -84,6 +84,12 @@ class ViewController: UIViewController {
         if Device.size < .Screen4_7Inch {
             print("Your device screen is smaller than 4.7 inch")
         }
+        
+        print(Device.systemVersion)
+        
+        if Device.systemVersion > "9.0" {
+            print("The iOS version is greater than 9.0")
+        }
     }
 
     override func didReceiveMemoryWarning() {

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run `carthage update` to build the framework and drag the built `Device.framewor
 ```swift
 func myFunc() {
         /*** Display the device version ***/
-        switch Device.version() {
+        switch Device.version {
             /*** iPhone ***/
             case .iPhone4:       print("It's an iPhone 4")
             case .iPhone4S:      print("It's an iPhone 4S")
@@ -88,7 +88,7 @@ func myFunc() {
 ```swift
 func myFunc() {
         /*** Display the device screen size ***/
-        switch Device.size() {
+        switch Device.size {
             case .Screen3_5Inch: print("It's a 3.5 inch screen")
             case .Screen4Inch:   print("It's a 4 inch screen")
             case .Screen4_7Inch: print("It's a 4.7 inch screen")
@@ -102,7 +102,7 @@ func myFunc() {
 ```swift
 func myFunc() {
         /*** Display the device type ***/
-        switch Device.type() {
+        switch Device.type {
             case .iPod:         print("It's an iPod")
             case .iPhone:       print("It's an iPhone")
             case .iPad:         print("It's an iPad")
@@ -116,15 +116,15 @@ func myFunc() {
 ```swift
 func myFunc() {
         /*** Helpers ***/
-        if Device.isEqualToScreenSize(Size.Screen4Inch) {
+        if Device.size == .Screen4Inch {
             print("It's a 4 inch screen")
         }
 
-        if Device.isLargerThanScreenSize(Size.Screen4_7Inch) {
+        if Device.size > .Screen4_7Inch {
             print("Your device screen is larger than 4.7 inch")
         }
 
-        if Device.isSmallerThanScreenSize(Size.Screen4_7Inch) {
+        if Device.size < .Screen4_7Inch {
             print("Your device screen is smaller than 4.7 inch")
         }
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ func myFunc() {
 }
 ```
 
+## Device system version
+```swift
+func myFunc() {
+    /*** Display the device system version ***/
+    print(Device.systemVersion)
+
+    if Device.systemVersion > "9.0" {
+        print("The iOS version is greater than 9.0")
+    }
+}
+```
+
 ## Helpers
 ```swift
 func myFunc() {

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -8,53 +8,32 @@
 
 import UIKit
 
-public class Device {
-    static private func getVersionCode() -> String {
+public class 📱Device {
+    private lazy var versionCode: String = {
         var systemInfo = utsname()
         uname(&systemInfo)
         
         let versionCode: String = String(UTF8String: NSString(bytes: &systemInfo.machine, length: Int(_SYS_NAMELEN), encoding: NSASCIIStringEncoding)!.UTF8String)!
         
         return versionCode
+    }()
+    
+    private lazy var screenHeight: CGFloat = {
+        let size = UIScreen.mainScreen().bounds.size
+        return max(size.width, size.height)
+    }()
+    
+    public var version: Version {
+        return Version(code: versionCode)
     }
     
-    static private func getVersion(code code: String) -> Version {
-        return Version(code: code)
+    public var type: Type {
+        return Type(code: versionCode)
     }
     
-    static private func getType(code code: String) -> Type {
-        return Type(code: code)
-    }
-    
-    static public func version() -> Version {
-        let versionName = Device.getVersionCode()
-        
-        return Device.getVersion(code: versionName)
-    }
-    
-    static public func size() -> Size {
-        let w: Double = Double(CGRectGetWidth(UIScreen.mainScreen().bounds))
-        let h: Double = Double(CGRectGetHeight(UIScreen.mainScreen().bounds))
-        let screenHeight: Double = max(w, h)
-        
+    public var size: Size {
         return Size(height: screenHeight)
     }
-    
-    static public func type() -> Type {
-        let versionName = Device.getVersionCode()
-        
-        return Device.getType(code: versionName)
-    }
-    
-    static public func isEqualToScreenSize(size: Size) -> Bool {
-        return Device.size() == size
-    }
-    
-    static public func isLargerThanScreenSize(size: Size) -> Bool {
-        return Device.size() > size
-    }
-    
-    static public func isSmallerThanScreenSize(size: Size) -> Bool {
-        return Device.size() < size
-    }
 }
+
+public let Device = 📱Device()

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -23,6 +23,8 @@ public class 📱Device {
         return max(size.width, size.height)
     }()
     
+    private(set) public lazy var systemVersion = UIDevice.currentDevice().systemVersion
+    
     public var version: Version {
         return Version(code: versionCode)
     }

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -19,82 +19,12 @@ public class Device {
     }
     
     static private func getVersion(code code: String) -> Version {
-        switch code {
-            /*** iPhone ***/
-            case "iPhone3,1", "iPhone3,2", "iPhone3,3":      return Version.iPhone4
-            case "iPhone4,1", "iPhone4,2", "iPhone4,3":      return Version.iPhone4S
-            case "iPhone5,1", "iPhone5,2":                   return Version.iPhone5
-            case "iPhone5,3", "iPhone5,4":                   return Version.iPhone5C
-            case "iPhone6,1", "iPhone6,2":                   return Version.iPhone5S
-            case "iPhone7,2":                                return Version.iPhone6
-            case "iPhone7,1":                                return Version.iPhone6Plus
-            case "iPhone8,1":                                return Version.iPhone6S
-            case "iPhone8,2":                                return Version.iPhone6SPlus
-            
-            /*** iPad ***/
-            case "iPad1,1":                                  return Version.iPad1
-            case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": return Version.iPad2
-            case "iPad3,1", "iPad3,2", "iPad3,3":            return Version.iPad3
-            case "iPad3,4", "iPad3,5", "iPad3,6":            return Version.iPad4
-            case "iPad4,1", "iPad4,2", "iPad4,3":            return Version.iPadAir
-            case "iPad5,3", "iPad5,4":                       return Version.iPadAir2
-            case "iPad2,5", "iPad2,6", "iPad2,7":            return Version.iPadMini
-            case "iPad4,4", "iPad4,5", "iPad4,6":            return Version.iPadMini2
-            case "iPad4,7", "iPad4,8", "iPad4,9":            return Version.iPadMini3
-            case "iPad5,1", "iPad5,2":                       return Version.iPadMini4
-            case "iPad6,7", "iPad6,8":                       return Version.iPadPro
-            
-            /*** iPod ***/
-            case "iPod1,1":                                  return Version.iPodTouch1Gen
-            case "iPod2,1":                                  return Version.iPodTouch2Gen
-            case "iPod3,1":                                  return Version.iPodTouch3Gen
-            case "iPod4,1":                                  return Version.iPodTouch4Gen
-            case "iPod5,1":                                  return Version.iPodTouch5Gen
-            case "iPod7,1":                                  return Version.iPodTouch6Gen
-            
-            /*** Simulator ***/
-            case "i386", "x86_64":                           return Version.Simulator
-
-            default:                                         return Version.Unknown
-        }
+        return Version(code: code)
     }
     
     static private func getType(code code: String) -> Type {
         let versionCode = Device.getVersionCode()
-        
-        switch versionCode {
-            case "iPhone3,1", "iPhone3,2", "iPhone3,3",
-            "iPhone4,1", "iPhone4,2", "iPhone4,3",
-            "iPhone5,1", "iPhone5,2",
-            "iPhone5,3", "iPhone5,4",
-            "iPhone6,1", "iPhone6,2",
-            "iPhone7,2",
-            "iPhone7,1",
-            "iPhone8,1",
-            "iPhone8,2":                                    return Type.iPhone
-
-            case "iPad1,1",
-            "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4",
-            "iPad3,1", "iPad3,2", "iPad3,3",
-            "iPad3,4", "iPad3,5", "iPad3,6",
-            "iPad4,1", "iPad4,2", "iPad4,3",
-            "iPad5,3", "iPad5,4",
-            "iPad2,5", "iPad2,6", "iPad2,7",
-            "iPad4,4", "iPad4,5", "iPad4,6",
-            "iPad4,7", "iPad4,8", "iPad4,9",
-            "iPad5,1", "iPad5,2",
-            "iPad6,7", "iPad6,8":                           return Type.iPad
-
-            case "iPod1,1",
-            "iPod2,1",
-            "iPod3,1",
-            "iPod4,1",
-            "iPod5,1",
-            "iPod7,1":
-                                                            return Type.iPod
-            case "i386", "x86_64":                          return Type.Simulator
-            default:                                        return Type.Unknown
-        }
+        return Type(code: versionCode)
     }
 
     
@@ -109,18 +39,7 @@ public class Device {
         let h: Double = Double(CGRectGetHeight(UIScreen.mainScreen().bounds))
         let screenHeight: Double = max(w, h)
         
-        switch screenHeight {
-            case 480:
-                return Size.Screen3_5Inch
-            case 568:
-                return Size.Screen4Inch
-            case 667:
-                return UIScreen.mainScreen().scale == 3.0 ? Size.Screen5_5Inch : Size.Screen4_7Inch
-            case 736:
-                return Size.Screen5_5Inch
-            default:
-                return Size.UnknownSize
-        }
+        return Size(height: screenHeight)
     }
     
     static public func type() -> Type {

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -23,10 +23,8 @@ public class Device {
     }
     
     static private func getType(code code: String) -> Type {
-        let versionCode = Device.getVersionCode()
-        return Type(code: versionCode)
+        return Type(code: code)
     }
-
     
     static public func version() -> Version {
         let versionName = Device.getVersionCode()

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -49,14 +49,14 @@ public class Device {
     }
     
     static public func isEqualToScreenSize(size: Size) -> Bool {
-        return size == Device.size() ? true : false;
+        return Device.size() == size
     }
     
     static public func isLargerThanScreenSize(size: Size) -> Bool {
-        return size.rawValue < Device.size().rawValue ? true : false;
+        return Device.size() > size
     }
     
     static public func isSmallerThanScreenSize(size: Size) -> Bool {
-        return size.rawValue > Device.size().rawValue ? true : false;
+        return Device.size() < size
     }
 }

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-public enum Size: Int {
-    case UnknownSize = 0
+public enum Size {
+    case UnknownSize
     case Screen3_5Inch
     case Screen4Inch
     case Screen4_7Inch
@@ -34,9 +34,9 @@ public enum Size: Int {
 extension Size: Comparable {}
 
 public func ==(x: Size, y: Size) -> Bool {
-    return x.rawValue == y.rawValue
+    return x.hashValue == y.hashValue
 }
 
 public func <(x: Size, y: Size) -> Bool {
-    return x.rawValue < y.rawValue
+    return x.hashValue < y.hashValue
 }

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -6,10 +6,27 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
+import UIKit
+
 public enum Size: Int {
     case UnknownSize = 0
     case Screen3_5Inch
     case Screen4Inch
     case Screen4_7Inch
     case Screen5_5Inch
+    
+    init(height: Double) {
+        switch height {
+        case 480:
+            self = .Screen3_5Inch
+        case 568:
+            self = .Screen4Inch
+        case 667:
+            self = UIScreen.mainScreen().scale == 3.0 ? .Screen5_5Inch : .Screen4_7Inch
+        case 736:
+            self = .Screen5_5Inch
+        default:
+            self = .UnknownSize
+        }
+    }
 }

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -15,7 +15,7 @@ public enum Size: Int {
     case Screen4_7Inch
     case Screen5_5Inch
     
-    init(height: Double) {
+    init(height: CGFloat) {
         switch height {
         case 480:
             self = .Screen3_5Inch

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 public enum Size {
-    case UnknownSize
+    case Unknown
     case Screen3_5Inch
     case Screen4Inch
     case Screen4_7Inch
@@ -26,7 +26,7 @@ public enum Size {
         case 736:
             self = .Screen5_5Inch
         default:
-            self = .UnknownSize
+            self = .Unknown
         }
     }
 }

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -30,3 +30,13 @@ public enum Size: Int {
         }
     }
 }
+
+extension Size: Comparable {}
+
+public func ==(x: Size, y: Size) -> Bool {
+    return x.rawValue == y.rawValue
+}
+
+public func <(x: Size, y: Size) -> Bool {
+    return x.rawValue < y.rawValue
+}

--- a/Source/Type.swift
+++ b/Source/Type.swift
@@ -12,4 +12,40 @@ public enum Type: String {
     case iPod
     case Simulator
     case Unknown
+    
+    init(code: String) {
+        switch code {
+        case "iPhone3,1", "iPhone3,2", "iPhone3,3",
+        "iPhone4,1", "iPhone4,2", "iPhone4,3",
+        "iPhone5,1", "iPhone5,2",
+        "iPhone5,3", "iPhone5,4",
+        "iPhone6,1", "iPhone6,2",
+        "iPhone7,2",
+        "iPhone7,1",
+        "iPhone8,1",
+        "iPhone8,2":                                    self = .iPhone
+            
+        case "iPad1,1",
+        "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4",
+        "iPad3,1", "iPad3,2", "iPad3,3",
+        "iPad3,4", "iPad3,5", "iPad3,6",
+        "iPad4,1", "iPad4,2", "iPad4,3",
+        "iPad5,3", "iPad5,4",
+        "iPad2,5", "iPad2,6", "iPad2,7",
+        "iPad4,4", "iPad4,5", "iPad4,6",
+        "iPad4,7", "iPad4,8", "iPad4,9",
+        "iPad5,1", "iPad5,2",
+        "iPad6,7", "iPad6,8":                           self = .iPad
+            
+        case "iPod1,1",
+        "iPod2,1",
+        "iPod3,1",
+        "iPod4,1",
+        "iPod5,1",
+        "iPod7,1":
+                                                        self = .iPod
+        case "i386", "x86_64":                          self = .Simulator
+        default:                                        self = .Unknown
+        }
+    }
 }

--- a/Source/Type.swift
+++ b/Source/Type.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
-public enum Type: String {
+public enum Type {
     case iPhone
     case iPad
     case iPod

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -44,4 +44,45 @@ public enum Version: String {
     
     /*** Unknown ***/
     case Unknown
+    
+    init(code: String) {
+        switch code {
+            /*** iPhone ***/
+        case "iPhone3,1", "iPhone3,2", "iPhone3,3":      self = .iPhone4
+        case "iPhone4,1", "iPhone4,2", "iPhone4,3":      self = .iPhone4S
+        case "iPhone5,1", "iPhone5,2":                   self = .iPhone5
+        case "iPhone5,3", "iPhone5,4":                   self = .iPhone5C
+        case "iPhone6,1", "iPhone6,2":                   self = .iPhone5S
+        case "iPhone7,2":                                self = .iPhone6
+        case "iPhone7,1":                                self = .iPhone6Plus
+        case "iPhone8,1":                                self = .iPhone6S
+        case "iPhone8,2":                                self = .iPhone6SPlus
+            
+            /*** iPad ***/
+        case "iPad1,1":                                  self = .iPad1
+        case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": self = .iPad2
+        case "iPad3,1", "iPad3,2", "iPad3,3":            self = .iPad3
+        case "iPad3,4", "iPad3,5", "iPad3,6":            self = .iPad4
+        case "iPad4,1", "iPad4,2", "iPad4,3":            self = .iPadAir
+        case "iPad5,3", "iPad5,4":                       self = .iPadAir2
+        case "iPad2,5", "iPad2,6", "iPad2,7":            self = .iPadMini
+        case "iPad4,4", "iPad4,5", "iPad4,6":            self = .iPadMini2
+        case "iPad4,7", "iPad4,8", "iPad4,9":            self = .iPadMini3
+        case "iPad5,1", "iPad5,2":                       self = .iPadMini4
+        case "iPad6,7", "iPad6,8":                       self = .iPadPro
+            
+            /*** iPod ***/
+        case "iPod1,1":                                  self = .iPodTouch1Gen
+        case "iPod2,1":                                  self = .iPodTouch2Gen
+        case "iPod3,1":                                  self = .iPodTouch3Gen
+        case "iPod4,1":                                  self = .iPodTouch4Gen
+        case "iPod5,1":                                  self = .iPodTouch5Gen
+        case "iPod7,1":                                  self = .iPodTouch6Gen
+            
+            /*** Simulator ***/
+        case "i386", "x86_64":                           self = .Simulator
+            
+        default:                                         self = .Unknown
+        }
+    }
 }

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
-public enum Version: String {
+public enum Version {
     /*** iPhone ***/
     case iPhone4
     case iPhone4S


### PR DESCRIPTION
Hey, thanks for the lib!

This PR introduces some breaking changes and I would love to discuss them.
- `versionCode` and `screenHeight` are lazily evaluated
- `device`, `type` and `size` are now properties
- `Size` conforms to the Comparable protocol
- Add `Device.systemVersion`

The updated version of the README is [here](https://github.com/delba/Device/blob/lazy/README.md)

Feedback welcomed :smiley:
