### PR TITLE
Implement Comparable protocol for Size

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -79,15 +79,15 @@ class ViewController: UIViewController {
         }
         
         /*** Helpers ***/
-        if Device.isEqualToScreenSize(Size.screen4Inch) {
+        if Device.size() == Size.screen4Inch {
             print("It's a 4 inch screen")
         }
-        
-        if Device.isLargerThanScreenSize(Size.screen4_7Inch) {
+
+        if Device.size() > Size.screen4_7Inch {
             print("Your device screen is larger than 4.7 inch")
         }
-        
-        if Device.isSmallerThanScreenSize(Size.screen4_7Inch) {
+
+        if Device.size() < Size.screen4_7Inch {
             print("Your device screen is smaller than 4.7 inch")
         }
     }

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -118,15 +118,18 @@ open class Device {
         
         return Device.getType(code: versionName)
     }
-    
+
+    @available(*, deprecated, message: "use == operator instead")
     static open func isEqualToScreenSize(_ size: Size) -> Bool {
         return size == Device.size() ? true : false;
     }
-    
+
+    @available(*, deprecated, message: "use > operator instead")
     static open func isLargerThanScreenSize(_ size: Size) -> Bool {
         return size.rawValue < Device.size().rawValue ? true : false;
     }
-    
+
+    @available(*, deprecated, message: "use < operator instead")
     static open func isSmallerThanScreenSize(_ size: Size) -> Bool {
         return size.rawValue > Device.size().rawValue ? true : false;
     }

--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
-public enum Size: Int {
+public enum Size: Int, Comparable {
     case unknownSize = 0
     case screen3_5Inch
     case screen4Inch
@@ -15,4 +15,12 @@ public enum Size: Int {
     case screen7_9Inch
     case screen9_7Inch
     case screen12_9Inch
+}
+
+public func <(lhs: Size, rhs: Size) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
+public func ==(lhs: Size, rhs: Size) -> Bool {
+    return lhs.rawValue == rhs.rawValue
 }


### PR DESCRIPTION
Makes Size enum comparable:

```
if Device.size() > Size.screen4_7Inch {
    print("Greater than 4.7 inch")
}

if Device.size() == Size.screen4_7Inch {
    print("Screen has 4.7 inch")
}

Previously existing functions are still there, but marked as deprecated