### PR TITLE
Refactor/remove type inferenced variable

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -51,10 +51,10 @@ class ViewController: UIViewController {
             case .iPodTouch5Gen: print("It's a iPod touch generation 5")
             case .iPodTouch6Gen: print("It's a iPod touch generation 6")
             
-            /*** Simulator ***/
-            case .Simulator:    print("It's a Simulator")
+            /*** simulator ***/
+            case .simulator:    print("It's a Simulator")
             
-            /*** Unknown ***/
+            /*** unknown ***/
             default:            print("It's an unknown device")
         }
         
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
             case .iPod:         print("It's an iPod")
             case .iPhone:       print("It's an iPhone")
             case .iPad:         print("It's an iPad")
-            case .Simulator:    print("It's a Simulated device")
+            case .simulator:    print("It's a simulated device")
             default:            print("Unknown device type")
         }
         

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -90,24 +90,24 @@ open class Device {
         
         switch screenHeight {
             case 480:
-                return Size.screen3_5Inch
+                return .screen3_5Inch
             case 568:
-                return Size.screen4Inch
+                return .screen4Inch
             case 667:
-                return UIScreen.main.scale == 3.0 ? Size.screen5_5Inch : Size.screen4_7Inch
+                return UIScreen.main.scale == 3.0 ? .screen5_5Inch : .screen4_7Inch
             case 736:
-                return Size.screen5_5Inch
+                return .screen5_5Inch
             case 1024:
                 switch version() {
                     case .iPadMini,.iPadMini2,.iPadMini3,.iPadMini4:
-                        return Size.screen7_9Inch
+                        return .screen7_9Inch
                     default:
-                        return Size.screen9_7Inch
+                        return .screen9_7Inch
                 }
             case 1366:
-                return Size.screen12_9Inch
+                return .screen12_9Inch
             default:
-                return Size.unknownSize
+                return .unknownSize
         }
     }
     

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -63,7 +63,7 @@ open class Device {
     }
     
     static fileprivate func getType(code: String) -> Type {
-        let versionCode = Device.getVersionCode()
+        let versionCode = getVersionCode()
         
         if versionCode.contains("iPhone") {
             return Type.iPhone
@@ -80,9 +80,7 @@ open class Device {
 
     
     static open func version() -> Version {
-        let versionName = Device.getVersionCode()
-        
-        return Device.getVersion(code: versionName)
+        return getVersion(code: getVersionCode())
     }
     
     static open func size() -> Size {
@@ -100,7 +98,7 @@ open class Device {
             case 736:
                 return Size.screen5_5Inch
             case 1024:
-                switch Device.version() {
+                switch version() {
                     case .iPadMini,.iPadMini2,.iPadMini3,.iPadMini4:
                         return Size.screen7_9Inch
                     default:
@@ -114,21 +112,19 @@ open class Device {
     }
     
     static open func type() -> Type {
-        let versionName = Device.getVersionCode()
-        
-        return Device.getType(code: versionName)
+        return getType(code: getVersionCode())
     }
     
     static open func isEqualToScreenSize(_ size: Size) -> Bool {
-        return size == Device.size() ? true : false;
+        return size == size() ? true : false;
     }
     
     static open func isLargerThanScreenSize(_ size: Size) -> Bool {
-        return size.rawValue < Device.size().rawValue ? true : false;
+        return size.rawValue < size().rawValue ? true : false;
     }
     
     static open func isSmallerThanScreenSize(_ size: Size) -> Bool {
-        return size.rawValue > Device.size().rawValue ? true : false;
+        return size.rawValue > size().rawValue ? true : false;
     }
     
     static open func isRetina() -> Bool {
@@ -136,20 +132,20 @@ open class Device {
     }
 
     static open func isPad() -> Bool {
-        return Device.type() == .iPad
+        return type() == .iPad
     }
     
     static open func isPhone() -> Bool {
-        return Device.type() == .iPhone
+        return type() == .iPhone
         
     }
     
     static open func isPod() -> Bool {
-        return Device.type() == .iPod
+        return type() == .iPod
     }
     
     static open func isSimulator() -> Bool {
-        return Device.type() == .Simulator
+        return type() == .Simulator
     }
     
 }

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -115,15 +115,15 @@ open class Device {
     }
     
     static open func isEqualToScreenSize(_ size: Size) -> Bool {
-        return size == size() ? true : false;
+        return size == self.size() ? true : false;
     }
     
     static open func isLargerThanScreenSize(_ size: Size) -> Bool {
-        return size.rawValue < size().rawValue ? true : false;
+        return size.rawValue < self.size().rawValue ? true : false;
     }
     
     static open func isSmallerThanScreenSize(_ size: Size) -> Bool {
-        return size.rawValue > size().rawValue ? true : false;
+        return size.rawValue > self.size().rawValue ? true : false;
     }
     
     static open func isRetina() -> Bool {

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -66,15 +66,15 @@ open class Device {
         let versionCode = getVersionCode()
         
         if versionCode.contains("iPhone") {
-            return Type.iPhone
+            return .iPhone
         } else if versionCode.contains("iPad") {
-            return Type.iPad
+            return .iPad
         } else if versionCode.contains("iPod") {
-            return Type.iPod
+            return .iPod
         } else if versionCode == "i386" || versionCode == "x86_64" {
-            return Type.Simulator
+            return .Simulator
         } else {
-            return Type.Unknown
+            return .Unknown
         }
     }
 

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -21,44 +21,44 @@ open class Device {
     static fileprivate func getVersion(code: String) -> Version {
         switch code {
             /*** iPhone ***/
-            case "iPhone3,1", "iPhone3,2", "iPhone3,3":      return Version.iPhone4
-            case "iPhone4,1", "iPhone4,2", "iPhone4,3":      return Version.iPhone4S
-            case "iPhone5,1", "iPhone5,2":                   return Version.iPhone5
-            case "iPhone5,3", "iPhone5,4":                   return Version.iPhone5C
-            case "iPhone6,1", "iPhone6,2":                   return Version.iPhone5S
-            case "iPhone7,2":                                return Version.iPhone6
-            case "iPhone7,1":                                return Version.iPhone6Plus
-            case "iPhone8,1":                                return Version.iPhone6S
-            case "iPhone8,2":                                return Version.iPhone6SPlus
-            case "iPhone8,4":                                return Version.iPhoneSE
-            case "iPhone9,1", "iPhone9,3":                   return Version.iPhone7
-            case "iPhone9,2", "iPhone9,4":                   return Version.iPhone7Plus
+            case "iPhone3,1", "iPhone3,2", "iPhone3,3":      return .iPhone4
+            case "iPhone4,1", "iPhone4,2", "iPhone4,3":      return .iPhone4S
+            case "iPhone5,1", "iPhone5,2":                   return .iPhone5
+            case "iPhone5,3", "iPhone5,4":                   return .iPhone5C
+            case "iPhone6,1", "iPhone6,2":                   return .iPhone5S
+            case "iPhone7,2":                                return .iPhone6
+            case "iPhone7,1":                                return .iPhone6Plus
+            case "iPhone8,1":                                return .iPhone6S
+            case "iPhone8,2":                                return .iPhone6SPlus
+            case "iPhone8,4":                                return .iPhoneSE
+            case "iPhone9,1", "iPhone9,3":                   return .iPhone7
+            case "iPhone9,2", "iPhone9,4":                   return .iPhone7Plus
 
             /*** iPad ***/
-            case "iPad1,1":                                  return Version.iPad1
-            case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": return Version.iPad2
-            case "iPad3,1", "iPad3,2", "iPad3,3":            return Version.iPad3
-            case "iPad3,4", "iPad3,5", "iPad3,6":            return Version.iPad4
-            case "iPad4,1", "iPad4,2", "iPad4,3":            return Version.iPadAir
-            case "iPad5,3", "iPad5,4":                       return Version.iPadAir2
-            case "iPad2,5", "iPad2,6", "iPad2,7":            return Version.iPadMini
-            case "iPad4,4", "iPad4,5", "iPad4,6":            return Version.iPadMini2
-            case "iPad4,7", "iPad4,8", "iPad4,9":            return Version.iPadMini3
-            case "iPad5,1", "iPad5,2":                       return Version.iPadMini4
-            case "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8": return Version.iPadPro
+            case "iPad1,1":                                  return .iPad1
+            case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": return .iPad2
+            case "iPad3,1", "iPad3,2", "iPad3,3":            return .iPad3
+            case "iPad3,4", "iPad3,5", "iPad3,6":            return .iPad4
+            case "iPad4,1", "iPad4,2", "iPad4,3":            return .iPadAir
+            case "iPad5,3", "iPad5,4":                       return .iPadAir2
+            case "iPad2,5", "iPad2,6", "iPad2,7":            return .iPadMini
+            case "iPad4,4", "iPad4,5", "iPad4,6":            return .iPadMini2
+            case "iPad4,7", "iPad4,8", "iPad4,9":            return .iPadMini3
+            case "iPad5,1", "iPad5,2":                       return .iPadMini4
+            case "iPad6,3", "iPad6,4", "iPad6,7", "iPad6,8": return .iPadPro
             
             /*** iPod ***/
-            case "iPod1,1":                                  return Version.iPodTouch1Gen
-            case "iPod2,1":                                  return Version.iPodTouch2Gen
-            case "iPod3,1":                                  return Version.iPodTouch3Gen
-            case "iPod4,1":                                  return Version.iPodTouch4Gen
-            case "iPod5,1":                                  return Version.iPodTouch5Gen
-            case "iPod7,1":                                  return Version.iPodTouch6Gen
+            case "iPod1,1":                                  return .iPodTouch1Gen
+            case "iPod2,1":                                  return .iPodTouch2Gen
+            case "iPod3,1":                                  return .iPodTouch3Gen
+            case "iPod4,1":                                  return .iPodTouch4Gen
+            case "iPod5,1":                                  return .iPodTouch5Gen
+            case "iPod7,1":                                  return .iPodTouch6Gen
             
             /*** Simulator ***/
-            case "i386", "x86_64":                           return Version.Simulator
+            case "i386", "x86_64":                           return .Simulator
 
-            default:                                         return Version.Unknown
+            default:                                         return .Unknown
         }
     }
     

--- a/Source/Device.swift
+++ b/Source/Device.swift
@@ -56,9 +56,9 @@ open class Device {
             case "iPod7,1":                                  return .iPodTouch6Gen
             
             /*** Simulator ***/
-            case "i386", "x86_64":                           return .Simulator
+            case "i386", "x86_64":                           return .simulator
 
-            default:                                         return .Unknown
+            default:                                         return .unknown
         }
     }
     
@@ -72,13 +72,12 @@ open class Device {
         } else if versionCode.contains("iPod") {
             return .iPod
         } else if versionCode == "i386" || versionCode == "x86_64" {
-            return .Simulator
+            return .simulator
         } else {
-            return .Unknown
+            return .unknown
         }
     }
 
-    
     static open func version() -> Version {
         return getVersion(code: getVersionCode())
     }
@@ -137,7 +136,6 @@ open class Device {
     
     static open func isPhone() -> Bool {
         return type() == .iPhone
-        
     }
     
     static open func isPod() -> Bool {
@@ -145,7 +143,7 @@ open class Device {
     }
     
     static open func isSimulator() -> Bool {
-        return type() == .Simulator
+        return type() == .simulator
     }
     
 }

--- a/Source/Type.swift
+++ b/Source/Type.swift
@@ -10,6 +10,6 @@ public enum Type: String {
     case iPhone
     case iPad
     case iPod
-    case Simulator
-    case Unknown
+    case simulator
+    case unknown
 }

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -42,9 +42,9 @@ public enum Version: String {
     case iPodTouch5Gen
     case iPodTouch6Gen
     
-    /*** Simulator ***/
-    case Simulator
+    /*** simulator ***/
+    case simulator
     
-    /*** Unknown ***/
-    case Unknown
+    /*** unknown ***/
+    case unknown
 }


### PR DESCRIPTION
1. enum case changed
- `Simulator` to `simulator
- `Unknown` to `unknown`

2. remove unnecessary variable should be type inferenced

- in func `getVersion` ex)`Version.iPhone4` to `.iPhone4`
- in func `getType` ex) `Type.iPhone` to `.iPhone`
- in func `size` ex) `Size.screen3_5Inch` to `.screen3_5Inch` 
