### PR TITLE
Fix warning in Xcode 10

### DIFF
--- a/Device.xcodeproj/project.pbxproj
+++ b/Device.xcodeproj/project.pbxproj
@@ -514,7 +514,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
@@ -536,7 +536,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -85,11 +85,11 @@ open class Device {
         }
     }
 
-    static open func version() -> Version {
+    static public func version() -> Version {
         return getVersion(code: getVersionCode())
     }
     
-    static open func size() -> Size {
+    static public func size() -> Size {
         let w: Double = Double(UIScreen.main.bounds.width)
         let h: Double = Double(UIScreen.main.bounds.height)
         let screenHeight: Double = max(w, h)
@@ -123,42 +123,42 @@ open class Device {
         }
     }
     
-    static open func type() -> Type {
+    static public func type() -> Type {
         return getType(code: getVersionCode())
     }
 
     @available(*, deprecated, message: "use == operator instead")
-    static open func isEqualToScreenSize(_ size: Size) -> Bool {
+    static public func isEqualToScreenSize(_ size: Size) -> Bool {
         return size == self.size() ? true : false;
     }
 
     @available(*, deprecated, message: "use > operator instead")
-    static open func isLargerThanScreenSize(_ size: Size) -> Bool {
+    static public func isLargerThanScreenSize(_ size: Size) -> Bool {
         return size.rawValue < self.size().rawValue ? true : false;
     }
 
     @available(*, deprecated, message: "use < operator instead")
-    static open func isSmallerThanScreenSize(_ size: Size) -> Bool {
+    static public func isSmallerThanScreenSize(_ size: Size) -> Bool {
         return size.rawValue > self.size().rawValue ? true : false;
     }
     
-    static open func isRetina() -> Bool {
+    static public func isRetina() -> Bool {
         return UIScreen.main.scale > 1.0
     }
 
-    static open func isPad() -> Bool {
+    static public func isPad() -> Bool {
         return type() == .iPad
     }
     
-    static open func isPhone() -> Bool {
+    static public func isPhone() -> Bool {
         return type() == .iPhone
     }
     
-    static open func isPod() -> Bool {
+    static public func isPod() -> Bool {
         return type() == .iPod
     }
     
-    static open func isSimulator() -> Bool {
+    static public func isSimulator() -> Bool {
         return type() == .simulator
     }
     


### PR DESCRIPTION
Mark some `open` api as `public` to fix Xcode warning. Also set `SWIFT_SWIFT3_OBJC_INFERENCE` to `Default`.