### PR TITLE
Add SwiftPM manifest and OS source guards

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "Device",
+    platforms: [.iOS(.v9), .macOS(.v10_10)],
+    products: [
+        .library(
+            name: "Device",
+            targets: ["Device"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "Device",
+            path: "Source"
+        )
+    ],
+    swiftLanguageVersions: [.v4, .v4_2, .v5]
+)

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
+#if os(iOS)
 import UIKit
 
 open class Device {
@@ -187,3 +188,4 @@ open class Device {
     }
     
 }
+#endif

--- a/Source/macOS/DeviceMacOS.swift
+++ b/Source/macOS/DeviceMacOS.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Ekhoo. All rights reserved.
 //
 
+#if os(OSX)
 import Cocoa
 
 public class Device {
@@ -81,3 +82,4 @@ public class Device {
     }
 
 }
+#endif


### PR DESCRIPTION
This allows usage of Device with Swift Package Manager.

Some build conditions are added to allow a single product and target for iOS and macOS.