### PR TITLE
Update device support tables

### DIFF
--- a/Source/Size.swift
+++ b/Source/Size.swift
@@ -9,11 +9,11 @@
 public enum Size: Int, Comparable {
     case unknownSize = 0
     #if os(iOS)
-    /// iPhone 4, 4s, iPod Touch 4th gen.
+    /// iPhone 2G, 3G, 3GS, 4, 4s, iPod Touch 4th gen.
     case screen3_5Inch
-    /// iPhone 5, 5s, 5c, SE, iPod Touch 5-6th gen.
+    /// iPhone 5, 5s, 5c, SE, iPod Touch 5-7th gen.
     case screen4Inch
-    /// iPhone 6, 6s, 7, 8
+    /// iPhone 6, 6s, 7, 8, SE 2nd gen.
     case screen4_7Inch
     /// iPhone 6+, 6s+, 7+, 8+
     case screen5_5Inch
@@ -25,12 +25,14 @@ public enum Size: Int, Comparable {
     case screen6_5Inch
     /// iPad Mini
     case screen7_9Inch
-    /// iPad
+    /// iPad, iPad Pro (9.7-inch)
     case screen9_7Inch
     /// iPad (10.2-inch)
     case screen10_2Inch
     /// iPad Pro (10.5-inch)
     case screen10_5Inch
+    /// iPad Air 4th gen.
+    case screen10_9Inch
     /// iPad Pro (11-inch)
     case screen11Inch
     /// iPad Pro (12.9-inch)
@@ -40,6 +42,7 @@ public enum Size: Int, Comparable {
     case screen12Inch
     case screen13Inch
     case screen15Inch
+    case screen16Inch
     case screen17Inch
     case screen20Inch
     case screen21_5Inch

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -8,6 +8,9 @@
 
 public enum Version: String {
     /*** iPhone ***/
+    case iPhone2G
+    case iPhone3G
+    case iPhone3GS
     case iPhone4
     case iPhone4S
     case iPhone5
@@ -29,7 +32,8 @@ public enum Version: String {
     case iPhone11
     case iPhone11Pro
     case iPhone11Pro_Max
-    
+    case iPhoneSE2
+
     /*** iPad ***/
     case iPad1
     case iPad2
@@ -38,13 +42,16 @@ public enum Version: String {
     case iPad5
     case iPad6
     case iPad7
+    case iPad8
     case iPadAir
     case iPadAir2
     case iPadAir3
+    case iPadAir4
     case iPadMini
     case iPadMini2
     case iPadMini3
     case iPadMini4
+    case iPadMini5
 
     /*** iPadPro ***/
     case iPadPro9_7Inch
@@ -53,7 +60,9 @@ public enum Version: String {
     case iPadPro12_9Inch2
     case iPadPro11_0Inch
     case iPadPro12_9Inch3
-    
+    case iPadPro11_0Inch2
+    case iPadPro12_9Inch4
+
     /*** iPod ***/
     case iPodTouch1Gen
     case iPodTouch2Gen
@@ -61,10 +70,11 @@ public enum Version: String {
     case iPodTouch4Gen
     case iPodTouch5Gen
     case iPodTouch6Gen
-    
+    case iPodTouch7Gen
+
     /*** simulator ***/
     case simulator
-    
+
     /*** unknown ***/
     case unknown
 }

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Ekhoo. All rights reserved.
 //
 
+#if os(iOS)
 import UIKit
 
 open class Device {
@@ -21,43 +22,50 @@ open class Device {
     static fileprivate func getVersion(code: String) -> Version {
         switch code {
             /*** iPhone ***/
-            case "iPhone3,1", "iPhone3,2", "iPhone3,3":     return .iPhone4
-            case "iPhone4,1", "iPhone4,2", "iPhone4,3":     return .iPhone4S
-            case "iPhone5,1", "iPhone5,2":                 return .iPhone5
-            case "iPhone5,3", "iPhone5,4":                 return .iPhone5C
-            case "iPhone6,1", "iPhone6,2":                 return .iPhone5S
-            case "iPhone7,2":                            return .iPhone6
-            case "iPhone7,1":                            return .iPhone6Plus
-            case "iPhone8,1":                            return .iPhone6S
-            case "iPhone8,2":                            return .iPhone6SPlus
-            case "iPhone8,3", "iPhone8,4":                 return .iPhoneSE
-            case "iPhone9,1", "iPhone9,3":                 return .iPhone7
-            case "iPhone9,2", "iPhone9,4":                 return .iPhone7Plus
-            case "iPhone10,1", "iPhone10,4":               return .iPhone8
-            case "iPhone10,2", "iPhone10,5":               return .iPhone8Plus
-            case "iPhone10,3", "iPhone10,6":               return .iPhoneX
-            case "iPhone11,2":                           return .iPhoneXS
-            case "iPhone11,4", "iPhone11,6":               return .iPhoneXS_Max
-            case "iPhone11,8":                           return .iPhoneXR
-            case "iPhone12,1":                return .iPhone11
-            case "iPhone12,3":                return .iPhone11Pro
-            case "iPhone12,5":                return .iPhone11Pro_Max
+            case "iPhone1,1":                                return .iPhone2G
+            case "iPhone1,2":                                return .iPhone3G
+            case "iPhone2,1":                                return .iPhone3GS
+            case "iPhone3,1", "iPhone3,2", "iPhone3,3":      return .iPhone4
+            case "iPhone4,1", "iPhone4,2", "iPhone4,3":      return .iPhone4S
+            case "iPhone5,1", "iPhone5,2":                   return .iPhone5
+            case "iPhone5,3", "iPhone5,4":                   return .iPhone5C
+            case "iPhone6,1", "iPhone6,2":                   return .iPhone5S
+            case "iPhone7,2":                                return .iPhone6
+            case "iPhone7,1":                                return .iPhone6Plus
+            case "iPhone8,1":                                return .iPhone6S
+            case "iPhone8,2":                                return .iPhone6SPlus
+            case "iPhone8,3", "iPhone8,4":                   return .iPhoneSE
+            case "iPhone9,1", "iPhone9,3":                   return .iPhone7
+            case "iPhone9,2", "iPhone9,4":                   return .iPhone7Plus
+            case "iPhone10,1", "iPhone10,4":                 return .iPhone8
+            case "iPhone10,2", "iPhone10,5":                 return .iPhone8Plus
+            case "iPhone10,3", "iPhone10,6":                 return .iPhoneX
+            case "iPhone11,2":                               return .iPhoneXS
+            case "iPhone11,4", "iPhone11,6":                 return .iPhoneXS_Max
+            case "iPhone11,8":                               return .iPhoneXR
+            case "iPhone12,1":                               return .iPhone11
+            case "iPhone12,3":                               return .iPhone11Pro
+            case "iPhone12,5":                               return .iPhone11Pro_Max
+            case "iPhone12,8":                               return .iPhoneSE2
 
-            
             /*** iPad ***/
-            case "iPad1,1", "iPad1,2":                    return .iPad1
+            case "iPad1,1", "iPad1,2":                       return .iPad1
             case "iPad2,1", "iPad2,2", "iPad2,3", "iPad2,4": return .iPad2
-            case "iPad3,1", "iPad3,2", "iPad3,3":           return .iPad3
-            case "iPad3,4", "iPad3,5", "iPad3,6":           return .iPad4
-            case "iPad6,11", "iPad6,12":                   return .iPad5
-            case "iPad7,5", "iPad7,6":                    return .iPad6
-            case "iPad4,1", "iPad4,2", "iPad4,3":           return .iPadAir
-            case "iPad5,3", "iPad5,4":                     return .iPadAir2
-            case "iPad11,3", "iPad11,4":                   return .iPadAir3
-            case "iPad2,5", "iPad2,6", "iPad2,7":           return .iPadMini
-            case "iPad4,4", "iPad4,5", "iPad4,6":           return .iPadMini2
-            case "iPad4,7", "iPad4,8", "iPad4,9":           return .iPadMini3
-            case "iPad5,1", "iPad5,2":                     return .iPadMini4
+            case "iPad3,1", "iPad3,2", "iPad3,3":            return .iPad3
+            case "iPad3,4", "iPad3,5", "iPad3,6":            return .iPad4
+            case "iPad6,11", "iPad6,12":                     return .iPad5
+            case "iPad7,5", "iPad7,6":                       return .iPad6
+            case "iPad7,11", "iPad7,12":                     return .iPad7
+            case "iPad11,6", "iPad11,7":                     return .iPad8
+            case "iPad4,1", "iPad4,2", "iPad4,3":            return .iPadAir
+            case "iPad5,3", "iPad5,4":                       return .iPadAir2
+            case "iPad11,3", "iPad11,4":                     return .iPadAir3
+            case "iPad13,1", "iPad13,2":                     return .iPadAir4
+            case "iPad2,5", "iPad2,6", "iPad2,7":            return .iPadMini
+            case "iPad4,4", "iPad4,5", "iPad4,6":            return .iPadMini2
+            case "iPad4,7", "iPad4,8", "iPad4,9":            return .iPadMini3
+            case "iPad5,1", "iPad5,2":                       return .iPadMini4
+            case "iPad11,1", "iPad11,2":                     return .iPadMini5
 
             /*** iPadPro ***/
             case "iPad6,3", "iPad6,4":                       return .iPadPro9_7Inch
@@ -66,7 +74,9 @@ open class Device {
             case "iPad7,3", "iPad7,4":                       return .iPadPro10_5Inch
             case "iPad8,1", "iPad8,2", "iPad8,3", "iPad8,4": return .iPadPro11_0Inch
             case "iPad8,5", "iPad8,6", "iPad8,7", "iPad8,8": return .iPadPro12_9Inch3
-            
+            case "iPad8,9", "iPad8,10":                      return .iPadPro11_0Inch2
+            case "iPad8,11", "iPad8,12":                     return .iPadPro12_9Inch4
+
             /*** iPod ***/
             case "iPod1,1":                                  return .iPodTouch1Gen
             case "iPod2,1":                                  return .iPodTouch2Gen
@@ -74,7 +84,8 @@ open class Device {
             case "iPod4,1":                                  return .iPodTouch4Gen
             case "iPod5,1":                                  return .iPodTouch5Gen
             case "iPod7,1":                                  return .iPodTouch6Gen
-            
+            case "iPod9,1":                                  return .iPodTouch7Gen
+
             /*** Simulator ***/
             case "i386", "x86_64":                           return .simulator
 
@@ -108,7 +119,7 @@ open class Device {
         let screenHeight: Double = max(w, h)
         
         switch screenHeight {
-            case 480:
+            case 240,480:
                 return .screen3_5Inch
             case 568:
                 return .screen4Inch
@@ -120,14 +131,14 @@ open class Device {
                 return .screen5_8Inch
             case 896:
                 switch version() {
-                case .iPhoneXS_Max:
+                case .iPhoneXS_Max,.iPhone11Pro_Max:
                     return .screen6_5Inch
                 default:
                     return .screen6_1Inch
                 }
             case 1024:
                 switch version() {
-                case .iPadMini,.iPadMini2,.iPadMini3,.iPadMini4:
+                case .iPadMini,.iPadMini2,.iPadMini3,.iPadMini4,.iPadMini5:
                     return .screen7_9Inch
                 case .iPadPro10_5Inch:
                     return .screen10_5Inch
@@ -138,6 +149,8 @@ open class Device {
                 return .screen10_2Inch
             case 1112:
                 return .screen10_5Inch
+            case 1180:
+                return .screen10_9Inch
             case 1194:
                 return .screen11Inch
             case 1366:
@@ -187,3 +200,4 @@ open class Device {
     }
     
 }
+#endif

--- a/Source/macOS/DeviceMacOS.swift
+++ b/Source/macOS/DeviceMacOS.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 Ekhoo. All rights reserved.
 //
 
+#if os(OSX)
 import Cocoa
 
 public class Device {
@@ -56,6 +57,8 @@ public class Device {
             return Size.screen13Inch
         case 15:
             return Size.screen15Inch
+        case 16:
+            return Size.screen16Inch
         case 17:
             return Size.screen17Inch
         case 20:
@@ -81,3 +84,4 @@ public class Device {
     }
 
 }
+#endif


### PR DESCRIPTION
This adds support for the following devices:

* iPhone (2G)
* iPhone 3G
* iPhone 3GS
* iPhone SE 2
* iPad Mini 5
* iPad 8
* iPad Air 4
* iPad Pro 11" 2
* iPad Pro 12,9" 4
* iPod Touch 7

The following screen sizes are added:

* iOS 10.9 Inch (iPad Air 4)
* iOS 6.5 Inch (iPhone 11 Pro Max, fixes #94)
* macOS 16 Inch (MacBook Pro)

Resolves #90, #94, #101