### PR TITLE
Add new iPads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ DerivedData
 
 Carthage/Build
 .DS_Store
+.build

--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -67,6 +67,7 @@ public enum Version: String {
     case iPad8
     case iPad9
     case iPad10
+    case iPadA16
     case iPadAir
     case iPadAir2
     case iPadAir3
@@ -81,6 +82,8 @@ public enum Version: String {
     case iPadMini7
     case iPadAirM2_11Inch
     case iPadAirM2_13Inch
+    case iPadAirM3_11Inch
+    case iPadAirM3_13Inch
 
     /*** iPadPro ***/
     case iPadPro9_7Inch

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -81,6 +81,7 @@ open class Device {
             case "iPad11,6", "iPad11,7":                     return .iPad8
             case "iPad12,1", "iPad12,2":                     return .iPad9
             case "iPad13,18", "iPad13,19":                   return .iPad10
+            case "iPad15,7", "iPad15,8":                     return .iPadA16
             case "iPad4,1", "iPad4,2", "iPad4,3":            return .iPadAir
             case "iPad5,3", "iPad5,4":                       return .iPadAir2
             case "iPad11,3", "iPad11,4":                     return .iPadAir3
@@ -95,6 +96,8 @@ open class Device {
             case "iPad16,1", "iPad16,2":                     return .iPadMini7
             case "iPad14,8", "iPad14,9":                     return .iPadAirM2_11Inch
             case "iPad14,10", "iPad14,11":                   return .iPadAirM2_13Inch
+            case "iPad15,3", "iPad15,4":                     return .iPadAirM3_11Inch
+            case "iPad15,5", "iPad15,6":                     return .iPadAirM3_13Inch
 
             /*** iPadPro ***/
             case "iPad6,3", "iPad6,4":                       return .iPadPro9_7Inch


### PR DESCRIPTION
[reference](https://everyi.com/by-year/ipod-iphone-ipad-models-released-in-2025.html)