### PR TITLE
New Device: iPhone 17 series & iPhone Air

### DIFF
--- a/Source/Version.swift
+++ b/Source/Version.swift
@@ -55,6 +55,10 @@ public enum Version: String {
     case iPhone16Pro
     case iPhone16Pro_Max
     case iPhone16e
+    case iPhone17
+    case iPhone17Pro
+    case iPhone17Pro_Max
+    case iPhoneAir
 
     /*** iPad ***/
     case iPad1

--- a/Source/iOS/Device.swift
+++ b/Source/iOS/Device.swift
@@ -78,6 +78,10 @@ open class Device {
             case "iPhone17,1":                               return .iPhone16Pro
             case "iPhone17,2":                               return .iPhone16Pro_Max
             case "iPhone17,5":                               return .iPhone16e
+            case "iPhone18,1":                               return .iPhone17Pro
+            case "iPhone18,2":                               return .iPhone17Pro_Max
+            case "iPhone18,3":                               return .iPhone17
+            case "iPhone18,4":                               return .iPhoneAir
 
             /*** iPad ***/
             case "iPad1,1", "iPad1,2":                       return .iPad1


### PR DESCRIPTION
This PR adds device codes of new iPhone 17 series along with iPhone Air.

- [`iPhone 17`](https://appledb.dev/device/iPhone18,3.html)
- [`iPhone 17 Pro`](https://appledb.dev/device/iPhone-17-Pro.html)
- [`iPhone 17 Pro Max`](https://appledb.dev/device/iPhone-17-Pro-Max.html)
- [`iPhone Air`](https://appledb.dev/device/iPhone18,4.html)